### PR TITLE
additionalProperties now reports name of the property that caused failure.

### DIFF
--- a/lib/draft-02/validation.js
+++ b/lib/draft-02/validation.js
@@ -303,7 +303,7 @@ module.exports = function () {
 		
 							if (!(key in props)) {
 						
-								return this.callPlugin(this.schema.fallbacks.additionalProperties, instance, 'additionalProperties')
+								return this.callPlugin(this.schema.fallbacks.additionalProperties, instance, 'additionalProperties', { propertyName : key })
 							}
 						}
 					}

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -198,11 +198,12 @@ module.exports = function () {
 
 		plugins: {
 
-			addError: function (instance, errorName) {
+			addError: function (instance, errorName, moreInfo) {
 
 				new this.Error(
 					errorName,
-					env.i18n['validation_error_'+errorName]
+					env.i18n['validation_error_'+errorName],
+					moreInfo
 				);
 				return instance;
 			}


### PR DESCRIPTION
I think being able to tell in the error message which property was "extra" is a very useful thing.
